### PR TITLE
Fix: NameError in ml_predictor and consolidate other fixes

### DIFF
--- a/ml_predictor.py
+++ b/ml_predictor.py
@@ -1,3 +1,4 @@
+import streamlit as st # Add missing import
 import pandas as pd
 import numpy as np
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor


### PR DESCRIPTION
- Add `import streamlit as st` to `ml_predictor.py` to resolve NameError.
- Modify `database.py` to default DATABASE_URL to 'sqlite:///mydb.sqlite3'.
- Refine symbol handling in `app.py` using `st.session_state` for robustness.
- Temporarily disable caching in data_fetcher and technical_analysis for debugging data update issues.
- Includes debug `st.write` statements in `app.py`.